### PR TITLE
 Remove a semicolon for ruby sass versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.2]
+- Remove a semicolon for ruby sass versions
+
 ## [1.1.1]
 - Change the tooltip's position to bottom and add styles for it
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealink-ecom-engine-css",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SeaLink Ecom Engine shared styles",
   "main": "sass/ecom.sass",
   "scripts": {

--- a/sass/ecom-engine-styles.sass
+++ b/sass/ecom-engine-styles.sass
@@ -1,1 +1,1 @@
-@import 'modules/tooltip.sass';
+@import 'modules/tooltip.sass'


### PR DESCRIPTION
 Remove a semicolon for ruby sass versions because it makes error on the ruby sass version (Captain Cook CMS)