### PR TITLE
Compatibility tweaks for Bootstrap v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [1.1.3]
-- Add styles for Bootstrap v4
+- Compativility tweaks for Bootstrap v4
 
 ## [1.1.2]
 - Remove a semicolon for ruby sass versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [1.1.3]
-- Compativility tweaks for Bootstrap v4
+- Compatibility tweaks for Bootstrap v4
 
 ## [1.1.2]
 - Remove a semicolon for ruby sass versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.3]
+- Add styles for Bootstrap v4
+
 ## [1.1.2]
 - Remove a semicolon for ruby sass versions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealink-ecom-engine-css",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "SeaLink Ecom Engine shared styles",
   "main": "sass/ecom.sass",
   "scripts": {

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -5,16 +5,16 @@
   height: 0
   border-color: transparent
   border-style: solid
-
-.tooltip.bottom
-  margin-top: 3px
-  padding: 5px 0
-  .tooltip-arrow
+  .tooltip.bottom &
     top: 0
     left: 50%
     margin-left: -5px
     border-width: 0 5px 5px
     border-bottom-color: #3d3b3b
+
+.tooltip.bottom
+  margin-top: 3px
+  padding: 5px 0
 
 // Tooltip
 [data-toggle="tooltip"]

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -1,16 +1,16 @@
-// Compativility tweaks for v4
-  .tooltip-arrow 
+// Compatibility tweaks for v4
+  .tooltip-arrow
     position: absolute
     width: 0
     height: 0
     border-color: transparent
     border-style: solid
 
-.tooltip.bottom 
+.tooltip.bottom
   margin-top: 3px
   padding: 5px 0
 
-.tooltip.bottom .tooltip-arrow 
+.tooltip.bottom .tooltip-arrow
   top: 0
   left: 50%
   margin-left: -5px

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -1,3 +1,22 @@
+// Competibility tweaks for v4
+  .tooltip-arrow 
+    position: absolute
+    width: 0
+    height: 0
+    border-color: transparent
+    border-style: solid
+
+.tooltip.bottom 
+  margin-top: 3px
+  padding: 5px 0
+
+.tooltip.bottom .tooltip-arrow 
+  top: 0
+  left: 50%
+  margin-left: -5px
+  border-width: 0 5px 5px
+  border-bottom-color: #3d3b3b
+
 // Tooltip
 [data-toggle="tooltip"]
   &:hover,
@@ -16,6 +35,7 @@
     background-position: center
     background-repeat: no-repeat
     background-size: contain
+
 .tooltip
   font-size: 14px
   font-weight: normal
@@ -39,4 +59,6 @@
     margin-left: 5px
     .tooltip-arrow
       border-right-color: #3d3b3b
+
+
 

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -1,4 +1,4 @@
-// Competibility tweaks for v4
+// Compativility tweaks for v4
   .tooltip-arrow 
     position: absolute
     width: 0

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -5,16 +5,16 @@
   height: 0
   border-color: transparent
   border-style: solid
-  .tooltip.bottom &
+
+.tooltip.bottom
+  margin-top: 3px
+  padding: 5px 0
+  .tooltip-arrow
     top: 0
     left: 50%
     margin-left: -5px
     border-width: 0 5px 5px
     border-bottom-color: #3d3b3b
-
-.tooltip.bottom
-  margin-top: 3px
-  padding: 5px 0
 
 // Tooltip
 [data-toggle="tooltip"]

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -1,21 +1,20 @@
 // Compatibility tweaks for v4
-  .tooltip-arrow
-    position: absolute
-    width: 0
-    height: 0
-    border-color: transparent
-    border-style: solid
+.tooltip-arrow
+  position: absolute
+  width: 0
+  height: 0
+  border-color: transparent
+  border-style: solid
 
 .tooltip.bottom
   margin-top: 3px
   padding: 5px 0
-
-.tooltip.bottom .tooltip-arrow
-  top: 0
-  left: 50%
-  margin-left: -5px
-  border-width: 0 5px 5px
-  border-bottom-color: #3d3b3b
+  .tooltip-arrow
+    top: 0
+    left: 50%
+    margin-left: -5px
+    border-width: 0 5px 5px
+    border-bottom-color: #3d3b3b
 
 // Tooltip
 [data-toggle="tooltip"]


### PR DESCRIPTION
We use the same Bootstrap js version(3.x) but use the different version for CSS per site. So the results can be a little bit different and I had to add more styles to fix this. Definitely, it would be better to use a single version in future. We don't have any big issue regarding this at the moment but each version generates different DOM structure which causes potential break for certain components.