### PR TITLE
Dc 594 change styles to remove i tag of tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.9]
+- Change styles to remove 'i' tag of Tooltip
+
 ## [1.1.3]
 - Compatibility tweaks for Bootstrap v4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealink-ecom-engine-css",
-  "version": "1.1.3",
+  "version": "1.1.9",
   "description": "SeaLink Ecom Engine shared styles",
   "main": "sass/ecom.sass",
   "scripts": {

--- a/sass/modules/tooltip.sass
+++ b/sass/modules/tooltip.sass
@@ -22,15 +22,15 @@
   &:active,
   &:focus
     outline: none
-  img,
-  i
-    &:hover
-      cursor: pointer
-  i
+  &:hover
+    cursor: pointer
+  &.icon-question-sign
     display: inline-block
-    width: 15px
-    height: 15px
-    background-image: url(/images/icons/info.svg)
+    width: 14px
+    height: 14px
+    line-height: 14px
+    margin-left: 3px
+    background-image: url(/images/ecom-engine/icons/info.svg)
     background-position: center
     background-repeat: no-repeat
     background-size: contain
@@ -58,6 +58,3 @@
     margin-left: 5px
     .tooltip-arrow
       border-right-color: #3d3b3b
-
-
-


### PR DESCRIPTION
**Why**
The tooltip used the <i> tag on HTML. It makes people hard to update contents on CMS. I removed the <i> tag and add a class to use styles.

**Review**
https://kis-next-cms.quicktravel.com.au/kangaroo-island-ferry/fares/