### PR TITLE
DC-710 numeric stepper css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0]
+- Add CSS for numeric steppers
+
 ## [1.1.10]
 - Improve UI for pax and vehicle type descriptions
 
@@ -18,4 +21,3 @@
 
 ## [1.0.0]
 - Initial release
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealink-ecom-engine-css",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "SeaLink Ecom Engine shared styles",
   "main": "sass/ecom.sass",
   "scripts": {

--- a/sass/ecom-engine-styles.sass
+++ b/sass/ecom-engine-styles.sass
@@ -1,2 +1,3 @@
-@import 'modules/tooltip.sass'
 @import 'modules/booking-search.sass'
+@import 'modules/numeric_stepper.sass'
+@import 'modules/tooltip.sass'

--- a/sass/modules/numeric_stepper.sass
+++ b/sass/modules/numeric_stepper.sass
@@ -1,0 +1,48 @@
+.stepper
+  margin-bottom: 0.5rem
+  display: flex
+  justify-content: space-between
+  align-items: center
+  padding: 0
+
+  .stepper-label
+    margin-right: 10px
+    flex: 1
+
+  .stepper-wrapper
+    display: flex
+    border: 1px solid #ccc
+    max-height: 42px
+
+    .stepper-button,
+    .stepper-value
+      display: inline-block
+      padding: 0.5rem 0.85rem
+      line-height: 1rem
+      height: 40px
+      border-radius: 0
+      border: none
+      box-shadow: none
+
+    .stepper-button
+      background: #efefef
+      color: #333
+
+      &:hover
+        background: #e0e0e0
+
+      &.stepper-button-disabled
+        i
+          opacity: 0.25
+
+    .stepper-value
+      width: 3rem
+      text-align: center
+
+.stepper + .stepper
+  margin-top: 1rem
+
+.pax-selection-row .refine-search-passenger-type-description
+  display: flex !important
+  margin-left: 0 !important
+  margin-bottom: 1.5rem !important


### PR DESCRIPTION
**Why**

Pax selection on transport search now uses numeric steppers. Instead of duplicating the CSS across projects it has been added here.

**Testing**

Steppers should look like steppers on all sites.

![screen shot 2017-12-19 at 1 06 52 pm](https://user-images.githubusercontent.com/1002901/34138050-99a4f946-e4bd-11e7-8893-8233f350e300.png)
