### PR TITLE
Dc 737 add note tooltips to luggage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.1]
+- Generalize Flex rule for numeric steppers
+
 ## [1.2.0]
 - Add CSS for numeric steppers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.2.1]
+## [Unreleased]
 - Generalize Flex rule for numeric steppers
 
 ## [1.2.0]

--- a/sass/modules/numeric_stepper.sass
+++ b/sass/modules/numeric_stepper.sass
@@ -39,10 +39,13 @@
       width: 3rem
       text-align: center
 
+.stepper ~ .refine-search-passenger-type-description,
+.stepper ~ .refine-search-vehicle-type-note
+  display: flex !important
+
 .stepper + .stepper
   margin-top: 1rem
 
 .pax-selection-row .refine-search-passenger-type-description
-  display: flex !important
   margin-left: 0 !important
   margin-bottom: 1.5rem !important


### PR DESCRIPTION
**WHY**
We would like to show notes under baggage options that look the same as the vehicle option notes and passenger notes