### PR TITLE
DC-853 styles for trip type layout 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix indenting issue
 * Add styles for the trip type of search panel
 * Generalize Flex rule for numeric steppers
+* Improve positioning of trip-type selector
 
 ## 1.2.4
 

--- a/sass/modules/refine-trip-type.sass
+++ b/sass/modules/refine-trip-type.sass
@@ -65,11 +65,8 @@
     input.check-dates-input
       padding-left: 18px
 
-@media screen and (min-width: 768px)
-  .refine-product-search-dates .return-date-label
-    margin-left: 5px
 
-@media screen and (min-width: 500px) and (max-width: 990px)
+@media screen and (min-width: 700px) and (max-width: 990px)
   .refine-product-search-dates
     .flex-layout
       justify-content: flex-start
@@ -78,9 +75,9 @@
 
 @media screen and (max-width: 340px)
   .refine-product-search-dates
+    input.check-dates-input
+      font-size: 0.9rem
+      padding-left: 0
+      width: 80px
     .flex-item:first-child
       padding-left: 0px
-    input.check-dates-input
-      font-size: 13px
-      padding-left: 0
-      width: 75px

--- a/sass/modules/refine-trip-type.sass
+++ b/sass/modules/refine-trip-type.sass
@@ -69,12 +69,7 @@
   .refine-product-search-dates .return-date-label
     margin-left: 5px
 
-@media screen and (max-width: 480px)
-  .refine-product-search-dates
-    .flex-layout
-      justify-content: space-between
-
-@media screen and (min-width: 481px)
+@media screen and (min-width: 500px) and (max-width: 990px)
   .refine-product-search-dates
     .flex-layout
       justify-content: flex-start
@@ -85,7 +80,6 @@
   .refine-product-search-dates
     .flex-item:first-child
       padding-left: 0px
-
     input.check-dates-input
       font-size: 13px
       padding-left: 0

--- a/sass/modules/trip-type.sass
+++ b/sass/modules/trip-type.sass
@@ -87,7 +87,7 @@
 
   .flex-layout
     margin: 0
-    justify-content: flex-start
+    justify-content: space-between
     display: flex
   .flex-item
     border: none
@@ -115,15 +115,11 @@
       &:before
         opacity: 0
 
-@media screen and (max-width: 767px)
+@media screen and (max-width: 500px)
   .product-search-dates
     padding: 0 10px
-
     .flex-item:first-child
       padding-left: 0px
-
-    .flex-layout
-      display: flex
 
     input.check-dates-input
       font-size: 0.93rem
@@ -135,7 +131,7 @@
     input.check-dates-input
       font-size: 0.9rem
       padding-left: 0px
-      width: 90px
+      width: 100%
 
     .product-search-date-icon
       display: none

--- a/sass/modules/trip-type.sass
+++ b/sass/modules/trip-type.sass
@@ -109,12 +109,6 @@
  * Media
  * ========================================================================== */
 
-@media screen and (min-width: 992px) and (max-width: 1199px)
-  .quick-search-container
-    .product-search-car.product-search-select-arrow
-      &:before
-        opacity: 0
-
 @media screen and (max-width: 500px)
   .product-search-dates
     padding: 0 10px


### PR DESCRIPTION
**Why**
- To use full width for trip type field.
- Change the homepage search panel layout for iPad

**Before**
![screen shot 2018-02-13 at 2 23 39 pm](https://user-images.githubusercontent.com/26703960/36132860-8d2135da-10c9-11e8-89ec-edcaf2680a0f.png)

**After**
![screen shot 2018-02-13 at 2 23 49 pm](https://user-images.githubusercontent.com/26703960/36132865-a52353ac-10c9-11e8-889e-891e08d1c9be.png)

iPad
![screen shot 2018-02-19 at 2 44 11 pm](https://user-images.githubusercontent.com/26703960/36362308-62a6c3b0-1583-11e8-8f84-7cc801428e9d.png)

